### PR TITLE
Initialize backend FastAPI skeleton

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,21 @@
 # Backend
+
+This directory contains the backend service built with FastAPI.
+
+## Setup
+
+Install dependencies using `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Run the development server with Uvicorn:
+
+```bash
+uvicorn main:app --reload
+```
+
+Visit `http://localhost:8000/` to see the **Hello, World** message.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello, World"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- set up a Python backend directory
- add FastAPI hello world endpoint
- document how to run the backend
- add requirements file

## Testing
- `python3 -m pip install fastapi uvicorn pydantic`
- `python backend/main.py >/tmp/out.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_687004d535a4832db996291ed6fa27f5