### PR TITLE
Add React frontend scaffold

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,19 @@
 # Frontend
+
+This directory contains the React + TypeScript web frontend.
+
+## Development
+
+Install dependencies (requires Node.js):
+
+```bash
+npm install
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` by default. It includes a page that fetches `/hello` from the backend and displays the response.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Robot Codex Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import HelloPage from './pages/HelloPage';
+
+const App: React.FC = () => {
+  return (
+    <div>
+      <h1>Robot Codex</h1>
+      <HelloPage />
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,5 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/HelloPage.tsx
+++ b/frontend/src/pages/HelloPage.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+
+const HelloPage: React.FC = () => {
+  const [message, setMessage] = useState<string>('');
+
+  useEffect(() => {
+    fetch('/hello')
+      .then((res) => res.text())
+      .then(setMessage)
+      .catch((err) => {
+        console.error(err);
+        setMessage('Failed to load');
+      });
+  }, []);
+
+  return <div>{message || 'Loading...'}</div>;
+};
+
+export default HelloPage;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["DOM", "ESNext"],
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a new React + TypeScript project using Vite in `frontend/`
- add `HelloPage` component that fetches from `/hello`
- document how to run the frontend

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6870057d1b48832db5db8c60a30416fc