### PR TITLE
Set up lint/test/build workflows and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black pytest pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Test
+        run: pytest backend
+      - name: Build
+        run: echo "Build backend"
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: |
+          npm install --prefix frontend
+      - name: Lint
+        run: npm run lint --prefix frontend
+      - name: Test
+        run: npm test --prefix frontend
+      - name: Build
+        run: npm run build --prefix frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.2.0
+    hooks:
+      - id: eslint
+        args: ["--max-warnings=0"]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ This repository is a monorepo containing all components of the Robot Codex proje
 - frontend/ - web frontend
 - infrastructure/ - infrastructure as code
 
+## Development
+
+This repository uses [pre-commit](https://pre-commit.com/) to enforce
+formatting with **black** and **eslint**. Install the hooks with:
+
+```bash
+pre-commit install
+```
+
+Running `pre-commit` locally ensures the same checks as the CI workflow.
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "lint": "echo \"no lint step yet\"",
+    "test": "echo \"no tests\"",
+    "build": "echo \"build frontend\""
+  }
+}


### PR DESCRIPTION
## Summary
- add CI workflow for backend and frontend
- configure pre-commit with black and eslint
- set up placeholder frontend npm scripts
- document development workflow

## Testing
- `pytest`
- `npm test --prefix frontend`
- `npm run build --prefix frontend`
- `pre-commit run --files README.md .pre-commit-config.yaml frontend/package.json .github/workflows/ci.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687005bdffd0832d97820648241b7344